### PR TITLE
Tiny fix to History example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ vector.
 ;; Quick and dirty history configuration.
 (let [h (History.)]
   (goog.events/listen h EventType/NAVIGATE #(secretary/dispatch! (.-token %)))
-  (doto h (.setEnabled h true)))
+  (doto h (.setEnabled true)))
 
 (secretary/dispatch! "/")
 ```


### PR DESCRIPTION
Haven't tested this, but seems that if you're using `doto` then you shouldn't provide `h` as the first argument to `set-enabled`?

Looks like a great library though - thanks! I'm currently doing a lot of this manually so this would be really helpful.

James
