### PR TITLE
restores any-matches? functionality

### DIFF
--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -178,7 +178,7 @@
 ;;======================================================================
 ;; Route lookup and dispatch
 
-(defn- locate-route [route]
+(defn locate-route [route]
   (some
    (fn [[compiled-route action]]
      (when-let [params (route-matches compiled-route route)]


### PR DESCRIPTION
Straightforward aliasing of private function `locate-route` to public predicate `any-matches?`.
