### PR TITLE
adds route-spec function to IRouteMatches protocol to return original route

### DIFF
--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -187,10 +187,6 @@
     (defroute "/my-route/:some-param" [params])
     (defroute #"my-regexp-route-[a-zA-Z]*" [params])
 
-    (is (= "/my-route/:some-param"
-           (last (secretary/locate-route "/my-route/100"))))
-
-    ;; I compare with pr-str as I can't get equality with RegExps
-    (is (= (pr-str #"my-regexp-route-[a-zA-Z]*")
-           (pr-str (last (secretary/locate-route "my-regexp-route-test")))))
-    (is (= js/RegExp (type (last (secretary/locate-route "my-regexp-route-test")))))))
+    (is (= "/my-route/:some-param" (secretary/locate-route-value "/my-route/100")))
+    (is (= (.-source #"my-regexp-route-[a-zA-Z]*")
+           (.-source (secretary/locate-route-value "my-regexp-route-test"))))))


### PR DESCRIPTION
...and returns original route as locate-route's third vector value.

I'm proposing this because I need a way to get the original route back from a specific route that has been requested.

It may make sense to further alter locate-route's return value so it returns a hash-map vs. a vector--as it is it's a bit awkward--but I didn't want to go too far with this at this point before seeing what you thought.

Another thing that may be useful is to return the name of the route if the route is a named route.
