### PR TITLE
Remove spurious "No such namespace: goog.events.EventType" warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ vector.
 ```clojure
 (ns example
   (:require [secretary.core :as secretary :include-macros true :refer [defroute]]
-            [goog.events :as events])
-  (:import goog.History
-           goog.history.EventType))
+            [goog.events :as events]
+            [goog.history.EventType :as EventType])
+  (:import goog.History))
 
 (def application
   (js/document.getElementById "application"))


### PR DESCRIPTION
Hey, this little fix to the README removes the warning about goog.events.EventType for me, and still seems to build correctly. This is a fix for #20 (though that's been closed already).
