### PR TITLE
Don't depend on route-params implementing IFn when rendering routes.

### DIFF
--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -340,7 +340,7 @@
                            (let [lookup (keyword (if (= $1 "*")
                                                    $1
                                                    (subs $1 1)))
-                                 v (@a lookup)
+                                 v (get @a lookup)
                                  replacement (if (sequential? v)
                                                (do
                                                  (swap! a assoc lookup (next v))


### PR DESCRIPTION
Fixes a bug when passed a record as route-params as it doesn't implement
`IFn` like normal maps do.

This allows you to write code like:

``` clojure
(defrecord Foo [id]]

(defroute foo-route "/foo/:id" [id]
  ...)

(let [some-foo (->Foo 42)]
  [:a {:href (foo-route some-foo)}])
```

I know that I could extend `Foo` with `IRenderRoute` in this (simplified) example, but there are some cases in my application where that wouldn't be an optimal solution. In addition, secretary shouldn't depend on the map implementing `IFn` in the same way `get` would behave.
