### PR TITLE
v2.0.0 (DO NOT MERGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add secretary to your `project.clj` `:dependencies` vector:
 For the current `SNAPSHOT` version use:
 
 ```clojure
-[secretary "2.0.0.1-d18a74"]
+[secretary "2.0.0.1-2b0752"]
 ```
 
 ## Guide

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ let's define a route for users with an id.
 ```
 
 In this example `show-user` is `name`, `"/users/:id"` is `route`, the
-route matcher, `{:as params}` is `destruct`, the destructured
+route matcher, `{{:keys [id]} :params}` is `destruct`, the destructured
 parameters extracted from the route matcher result, and the remaining
 `(js/console.log ...)` portion is `body`, the route action.
 
@@ -94,7 +94,7 @@ see that `User: gf3` has been logged somewhere.
 By default the route matcher may either be a string or regular
 expression. String route matchers have special syntax which may be
 familiar to you if you've worked with [Sinatra][sinatra] or
-[Ruby on Rails][rails]. When `secretary/dispatch!` is called with a
+[Ruby on Rails][rails]. When `dispatch!` is called with a
 URI it attempts to find a route match and it's corresponding
 action. If the match is successful, parameters will be extracted from
 the URI. For string route matchers these will be contained in a map;
@@ -128,7 +128,7 @@ them. Under the hood, for example with our users route, this looks
 something like the following.
 
 ```clojure
-(let [{:as params} {:params {:id "gf3"}]
+(let [{{id :id} :params} {:params {:id "gf3"}]
   ...)
 ```
 
@@ -160,16 +160,15 @@ destructuring since they only ever return vectors.
 #### Query parameters
 
 If a URI contains a query string it will automatically be extracted to
-`:query-params` for string route matchers and to the last element for
-regular expression matchers.
+`:query-params`.
 
 ```clojure
-(defroute show-user "/users/:id" [id query-params]
-  (js/console.log (str "User: " id))
+(defroute show-user "/users/:id" {:keys [params query-params]}
+  (js/console.log (pr-str (:id params)))
   (js/console.log (pr-str query-params)))
 
-(defroute show-user #"/users/(\d+)" [id {:keys [query-params]}]
-  (js/console.log (str "User: " id))
+(defroute show-user #"/users/(\d+)" {:keys [params query-params]}
+  (js/console.log (str "User: " (first params)))
   (js/console.log (pr-str query-params)))
 
 ;; In both instances...
@@ -209,7 +208,7 @@ If the browser you're targeting does not support HTML5 history you can
 call
 
 ```clojure
-(secretary/set-config! :prefix "#")
+(secretary/set-route-prefix! "#")
 ```
 
 to prefix generated URIs with a "#".

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add secretary to your `project.clj` `:dependencies` vector:
 For the current `SNAPSHOT` version use:
 
 ```clojure
-[secretary "1.2.2-SNAPSHOT"]
+[secretary "2.0.0.1-d18a74"]
 ```
 
 ## Guide

--- a/examples/example-01/example.cljs
+++ b/examples/example-01/example.cljs
@@ -18,7 +18,7 @@
   (set-html! application "<h1>OMG! YOU'RE HOME!</h1>"))
 
 ;; /#/users
-(defroute user-path "/users" []
+(defroute users-path "/users" []
   (set-html! application "<h1>USERS!</h1>"))
 
 ;; /#/users/:id
@@ -31,13 +31,21 @@
   (set-html! application "<h1>YOU HIT THE JACKPOT!</h1>"))
 
 ;; Catch all
-(defroute "*" []
+(defroute wildcard "*" []
   (set-html! application "<h1>LOL! YOU LOST!</h1>"))
+
+(def dispatch!
+  (secretary/uri-dispatcher
+   [home-path
+    users-path
+    user-path
+    jackpot-path
+    wildcard]))
 
 ;; Quick and dirty history configuration.
 (let [h (History.)]
-  (goog.events/listen h EventType.NAVIGATE #(secretary/dispatch! (.-token %)))
+  (goog.events/listen h EventType.NAVIGATE #(dispatch! (.-token %)))
   (doto h
     (.setEnabled true)))
 
-(secretary/dispatch! "/")
+(dispatch! "/")

--- a/project.clj
+++ b/project.clj
@@ -24,17 +24,17 @@
             :comments "same as Clojure"}
 
   :dependencies
-  [[org.clojure/clojure "1.6.0"]]
+  [[org.clojure/clojure "1.7.0"]]
 
   :profiles
   {:dev {:source-paths ["dev/" "src/"]
          :dependencies
-         [[org.clojure/clojurescript "0.0-3211"]
-          [com.cemerick/piggieback "0.1.6-SNAPSHOT"]
-          [weasel "0.6.0"]
-          [spellhouse/clairvoyant "0.0-33-g771b57f"]]
+         [[org.clojure/clojurescript "1.7.228"]
+          [com.cemerick/piggieback "0.2.1"]
+          [weasel "0.7.0"]
+          [spellhouse/clairvoyant "0.0-72-g15e1e44"]]
          :plugins
-         [[lein-cljsbuild "1.0.5"]
+         [[lein-cljsbuild "1.1.2"]
           [com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]
          :repl-options
          {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
   :profiles
   {:dev {:source-paths ["dev/" "src/"]
          :dependencies
-         [[org.clojure/clojurescript "0.0-3030"]
+         [[org.clojure/clojurescript "0.0-3211"]
           [com.cemerick/piggieback "0.1.6-SNAPSHOT"]
           [weasel "0.6.0"]
           [spellhouse/clairvoyant "0.0-33-g771b57f"]]

--- a/project.clj
+++ b/project.clj
@@ -7,15 +7,25 @@
             :comments "same as Clojure"}
 
   :dependencies
-  [[org.clojure/clojure "1.5.1"]
-   [org.clojure/clojurescript "0.0-2156" :scop "provided"]]
-
-  :plugins
-  [[lein-cljsbuild "1.0.2"]]
+  [[org.clojure/clojure "1.6.0"]]
 
   :profiles
-  {:dev {:plugins [[com.cemerick/austin "0.1.3"]
-                   [com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]}}
+  {:dev {:source-paths
+         ["src" "dev"]
+
+         :dependencies
+         [[org.clojure/clojurescript "0.0-2322"]
+          [weasel "0.4.0-SNAPSHOT"]
+          [spellhouse/clairvoyant "0.0-33-g771b57f"]]
+
+
+         :plugins
+         [[lein-cljsbuild "1.0.3"]
+          [com.cemerick/austin "0.1.3"]
+          [com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]
+
+         :repl-options
+         {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}
 
   :aliases
   {"run-tests" ["do" "clean," "cljsbuild" "once" "test"]
@@ -23,12 +33,21 @@
    "auto-test" ["do" "clean," "cljsbuild" "auto" "test"]}
 
   :cljsbuild
-  {:builds [{:id "test"
+  {:builds [{:id "dev"
+             :source-paths ["dev/" "src/"]
+             :compiler {:output-to "resources/public/secretary.js"
+                        :output-dir "resources/public/out"
+                        :optimizations :none
+                        :source-map true
+                        :pretty-print true}}
+
+            {:id "test"
              :source-paths ["src/" "test/"]
              :notify-command ["phantomjs" :cljs.test/runner "target/js/test.js"]
              :compiler {:output-to "target/js/test.js"
                         :optimizations :whitespace
                         :pretty-print true}}
+
             {:id "example-01"
              :source-paths ["src/" "examples/example-01"]
              :compiler {:output-to "examples/example-01/example.js"

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,6 @@
           [weasel "0.4.0-SNAPSHOT"]
           [spellhouse/clairvoyant "0.0-33-g771b57f"]]
 
-
          :plugins
          [[lein-cljsbuild "1.0.3"]
           [com.cemerick/austin "0.1.3"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject secretary "1.2.2-SNAPSHOT"
+(defproject secretary "2.0.0-SNAPSHOT"
   :description "A client-side router for ClojureScript."
   :url "https://github.com/gf3/secretary"
   :license {:name "Eclipse Public License - v 1.0"

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
   :profiles
   {:dev {:source-paths ["dev/" "src/"]
          :dependencies
-         [[org.clojure/clojurescript "0.0-2913"]
+         [[org.clojure/clojurescript "0.0-3030"]
           [com.cemerick/piggieback "0.1.6-SNAPSHOT"]
           [weasel "0.6.0"]
           [spellhouse/clairvoyant "0.0-33-g771b57f"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,21 @@
-(defproject secretary "2.0.0-SNAPSHOT"
+(require '[clojure.java.shell])
+
+(defn secretary-version
+  "Return the current version string."
+  [base-version {release? :release?}]
+  (if-not (true? release?)
+    (let [last-commit (-> (clojure.java.shell/sh "git" "rev-parse" "HEAD")
+                          (:out)
+                          (.trim))
+          revision (-> (clojure.java.shell/sh "git" (str "rev-list.." last-commit))
+                       (:out)
+                       (.. trim (split "\\n"))
+                       (count))
+          sha (subs last-commit 0 6)]
+      (str base-version "." revision "-" sha))
+    base-version))
+
+(defproject secretary (secretary-version "2.0.0" {:release? false})
   :description "A client-side router for ClojureScript."
   :url "https://github.com/gf3/secretary"
   :license {:name "Eclipse Public License - v 1.0"

--- a/project.clj
+++ b/project.clj
@@ -35,14 +35,16 @@
           [spellhouse/clairvoyant "0.0-72-g15e1e44"]]
          :plugins
          [[lein-cljsbuild "1.1.2"]
-          [com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]
+          [lein-doo "0.1.6"]]
          :repl-options
          {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}
 
+  :doo {:build "test"}
+
   :aliases
-  {"run-tests" ["do" "clean," "cljsbuild" "once" "test"]
-   "test-once" ["do" "clean," "cljsbuild" "once" "test"]
-   "auto-test" ["do" "clean," "cljsbuild" "auto" "test"]}
+  {"run-tests" ["do" "clean," "doo" "phantom" "test" "once"]
+   "test-once" ["do" "clean," "doo" "phantom" "test" "once"]
+   "auto-test" ["do" "clean," "doo" "phantom" "test" "auto"]}
 
   :cljsbuild
   {:builds [{:id "dev"
@@ -55,8 +57,8 @@
 
             {:id "test"
              :source-paths ["src/" "test/"]
-             :notify-command ["phantomjs" :cljs.test/runner "target/js/test.js"]
-             :compiler {:output-to "target/js/test.js"
+             :compiler {:main secretary.test.runner
+                        :output-to "target/js/test.js"
                         :optimizations :whitespace
                         :pretty-print true}}
 

--- a/src/secretary/codec.cljs
+++ b/src/secretary/codec.cljs
@@ -1,0 +1,137 @@
+(ns secretary.codec
+  (:require
+   [clojure.string :as string]
+   [clojure.walk :as walk]))
+
+;; ---------------------------------------------------------------------
+;; Parameter encoding
+
+(def encode js/encodeURIComponent)
+
+(defmulti
+  ^{:private true
+    :doc "Given a key and a value return and encoded key-value pair."}
+  encode-pair
+  (fn [[k v]]
+    (cond
+     (or (sequential? v) (set? v))
+     ::sequential
+     (or (map? v) (satisfies? IRecord v))
+     ::map)))
+
+(defn ^:private key-index
+  ([k]
+     (str (name k) "[]"))
+  ([k index]
+     (str (name k) "[" index "]")))
+
+(defmethod encode-pair ::sequential [[k v]]
+  (let [encoded (map-indexed
+                 (fn [i x]
+                   (let [pair (if (coll? x)
+                                [(key-index k i) x]
+                                [(key-index k) x])]
+                     (encode-pair pair)))
+                 v)]
+    (string/join \& encoded)))
+
+(defmethod encode-pair ::map [[k v]]
+  (let [encoded (map
+                 (fn [[ik iv]]
+                   (encode-pair [(key-index k (name ik)) iv]))
+                 v)]
+    (string/join \& encoded)))
+
+(defmethod encode-pair :default [[k v]]
+  (str (name k) \= (encode (str v))))
+
+(defn encode-query-params
+  "Convert a map of query parameters into url encoded string."
+  [query-params]
+  (string/join \& (map encode-pair query-params)))
+
+(defn encode-uri
+  "Like js/encodeURIComponent excepts ignore slashes."
+  [uri]
+  (->> (string/split uri #"/")
+       (map encode)
+       (string/join "/")))
+
+;;----------------------------------------------------------------------
+;; Parameter decoding
+
+(def decode js/decodeURIComponent)
+
+(defn ^:private parse-path
+  "Parse a value from a serialized query-string key index. If the
+  index value is empty 0 is returned, if it's a digit it returns the
+  js/parseInt value, otherwise it returns the extracted index."
+  [path]
+  (let [index-re #"\[([^\]]*)\]*" ;; Capture the index value.
+        parts (re-seq index-re path)]
+    (map
+     (fn [[_ part]]
+       (cond
+        (empty? part) 0
+        (re-matches #"\d+" part) (js/parseInt part)
+        :else part))
+     parts)))
+
+(defn ^:private key-parse
+  "Return a key path for a serialized query-string entry.
+
+  Ex.
+
+  (key-parse \"foo[][a][][b]\")
+  ;; => (\"foo\" 0 \"a\" 0 \"b\")
+  "
+  [k]
+  (let [re #"([^\[\]]+)((?:\[[^\]]*\])*)?"
+        [_ key path] (re-matches re k)
+        parsed-path (when path (parse-path path))]
+    (cons key parsed-path)))
+
+(defn ^:private assoc-in-query-params
+  "Like assoc-in but numbers in path create vectors instead of maps.
+
+  Ex.
+
+  (assoc-in-query-params {} [\"foo\" 0] 1)
+  ;; => {\"foo\" [1]}
+
+  (assoc-in-query-params {} [\"foo\" 0 \"a\"] 1)
+  ;; => {\"foo\" [{\"a\" 1}]}
+  "
+  [m path v]
+  (let [heads (fn [xs]
+                (map-indexed
+                 (fn [i _]
+                   (take (inc i) xs))
+                 xs))
+        hs (heads path)
+        m (reduce
+           (fn [m h]
+             (if (and (or (number? (last h)))
+                      (not (vector? (get-in m (butlast h)))))
+               (assoc-in m (butlast h) [])
+               m))
+           m
+           hs)]
+    (if (zero? (last path))
+      (update-in m (butlast path) conj v)
+      (assoc-in m path v))))
+
+(defn decode-query-params
+  "Extract a map of query parameters from a query string."
+  [query-string]
+  (let [parts (string/split query-string #"&")
+        params (reduce
+                (fn [m part]
+                  ;; We only want two parts since the part on the right hand side
+                  ;; could potentially contain an =.
+                  (let [[k v] (string/split part #"=" 2)]
+                    (assoc-in-query-params m (key-parse k) (decode v))))
+                {}
+                parts)
+        params (walk/keywordize-keys params)]
+    params))

--- a/src/secretary/core.clj
+++ b/src/secretary/core.clj
@@ -26,12 +26,22 @@
         (let [~destruct ~params]
           ~@body)))))
 
-(defmacro ^{:arglists '([name route destruct & body])}
+(defn- binding-exception [type destruct]
+  (IllegalArgumentException.
+   (str type " bindings must be a map or vector, given " (pr-str destruct))))
+
+(defmacro ^{:arglists '([pattern destruct & body])}
+  route
+  "Define an anonymous instance of secretary.core/Route."
+  [pattern destruct & body]
+  (when-not (or (map? destruct) (vector? destruct))
+    (throw (binding-exception "route" destruct)))
+  `(secretary.core/make-route ~pattern ~(route-action-form destruct body)))
+
+(defmacro ^{:arglists '([name pattern destruct & body])}
   defroute
-  "Define an instance of secretary.core/Route."
+  "Define a named instance of secretary.core/Route."
   [name pattern destruct & body]
   (when-not (or (map? destruct) (vector? destruct))
-    (throw (IllegalArgumentException.
-            (str "defroute bindings must be a map or vector, given " (pr-str destruct)))))
-  `(def ~name
-     (secretary.core/make-route ~pattern ~(route-action-form destruct body))))
+    (throw (binding-exception "defroute" destruct)))
+  `(def ~name (route ~pattern ~destruct ~body)))

--- a/src/secretary/core.clj
+++ b/src/secretary/core.clj
@@ -1,31 +1,24 @@
 (ns secretary.core)
 
-(defmacro ^{:arglists '([name? route destruct & body])}
+(defn ^:private route-action-form [destruct body]
+  `(fn [params#]
+     (cond
+      (map? params#)
+      (let [~(if (vector? destruct)
+               {:keys destruct}
+               destruct) params#]
+        ~@body)
+
+      (vector? params#)
+      (let [~destruct params#]
+        ~@body))))
+
+(defmacro ^{:arglists '([name route destruct & body])}
   defroute
-  "Add a route to the dispatcher."
-  [route destruct & body]
-  (let [[fn-name route destruct body] (if (symbol? route)
-                                        [route destruct (first body) (rest body)]
-                                        [nil route destruct body])
-        fn-spec `([& args#]
-                    (apply secretary.core/render-route* ~route args#))
-        fn-body (if fn-name
-                  (concat (list 'defn fn-name) fn-spec)
-                  (cons 'fn fn-spec))]
-
-    (when-not ((some-fn map? vector?) destruct)
-      (throw (IllegalArgumentException. (str "defroute bindings must be a map or vector, given " (pr-str destruct)))))
-
-    `(let [action# (fn [params#]
-                     (cond
-                      (map? params#)
-                      (let [~(if (vector? destruct)
-                               {:keys destruct}
-                               destruct) params#]
-                        ~@body)
-
-                      (vector? params#)
-                      (let [~destruct params#]
-                        ~@body)))]
-       (secretary.core/add-route! ~route action#)
-       ~fn-body)))
+  "Define an instance of secretary.core/Route."
+  [name pattern destruct & body]
+  (when-not (or (map? destruct) (vector? destruct))
+    (throw (IllegalArgumentException.
+            (str "defroute bindings must be a map or vector, given " (pr-str destruct)))))
+  `(def ~name
+     (secretary.core/make-route ~pattern ~(route-action-form destruct body))))

--- a/src/secretary/core.clj
+++ b/src/secretary/core.clj
@@ -18,22 +18,18 @@
                  [destruct (:params params)])]
          ~@body))))
 
-(defn- binding-exception [type destruct]
-  (IllegalArgumentException.
-   (str type " bindings must be a map or vector, given " (pr-str destruct))))
-
 (defmacro ^{:arglists '([pattern destruct & body])}
   route
   "Define an anonymous instance of secretary.core/Route."
   [pattern destruct & body]
   (when-not (or (map? destruct) (vector? destruct))
-    (throw (binding-exception "route" destruct)))
+    (throw (IllegalArgumentException.
+            (str "route bindings must be a map or vector, given "
+                 (pr-str destruct)))))
   `(secretary.core/make-route ~pattern ~(route-action-form destruct body)))
 
 (defmacro ^{:arglists '([name pattern destruct & body])}
   defroute
   "Define a named instance of secretary.core/Route."
   [name pattern destruct & body]
-  (when-not (or (map? destruct) (vector? destruct))
-    (throw (binding-exception "defroute" destruct)))
   `(def ~name (route ~pattern ~destruct ~body)))

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -5,6 +5,11 @@
   (:require-macros
    [secretary.core :refer [defroute]]))
 
+(def ^:dynamic *route-prefix* "")
+
+(defn set-route-prefix! [prefix]
+  (set! *route-prefix* prefix))
+
 ;; ---------------------------------------------------------------------
 ;; Protocols
 
@@ -248,8 +253,8 @@
                              replacement)))]
       (if-let [query-string (and query-params
                                  (codec/encode-query-params query-params))]
-        (str path "?" query-string)
-        path))))
+        (str *route-prefix* path "?" query-string)
+        (str *route-prefix* path)))))
 
 
 ;;; RegExp

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -189,7 +189,7 @@
       (handler req))))
 
 (defn uri-dispatcher
-  "Return an instance of Dispatcher which when invoked with a uri attempts 
+  "Return a dispatcher which when invoked with a uri attempts 
   to locate, match, and apply a routing action. Optionally a ring-style 
   handler may be passed."
   ([routes]
@@ -201,7 +201,9 @@
                    (wrap-query-params))
              {:keys [route] :as req} (h (request-map uri))]
          (when route
-           (.action route (dissoc req :route)))))))
+           (let [req-map (-> (dissoc req :route)
+                             (with-meta {:ring-route? true}))]
+             (.action route req-map)))))))
 
 
 ;; ---------------------------------------------------------------------

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -117,6 +117,7 @@
           (->> (interleave params (map js/decodeURIComponent ms))
                (partition 2)
                (merge-with vector {}))))
+
       IRenderRoute
       (-render-route [_]
         (-render-route s))
@@ -267,10 +268,16 @@
 (defn ^:private invalid-params [params validations]
   (reduce (fn [m [key validation]]
             (if-let [value (get params key)]
-              (if (re-matches validation value)
-                m
-                (assoc m key [value validation]))
-              m))
+              (cond
+               (regexp? validation)
+               (if (re-matches validation value)
+                 m
+                 (assoc m key [value validation]))
+               (ifn? validation)
+               (if (validation value)
+                 m
+                 (assoc m key [value validation]))
+               :else m)))
           {} (partition 2 validations)))
 
 (defn ^:private params-valid? [params validations]

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -180,7 +180,9 @@
 ;; URI dispatcher
 
 (defn request-map [s]
-  (let [[uri query-string] (string/split (or s "") #"\?")]
+  (let [[uri query-string] (string/split (str s) #"\?")
+        uri (str uri)
+        query-string (str query-string)]
     {:uri uri
      :query-string query-string}))
 

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -180,7 +180,7 @@
 ;; URI dispatcher
 
 (defn request-map [s]
-  (let [[uri query-string] (string/split s #"\?")]
+  (let [[uri query-string] (string/split (or s "") #"\?")]
     {:uri uri
      :query-string query-string}))
 

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -150,6 +150,7 @@
   (-render-route [this]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern)))
+
   (-render-route [this params]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern params)))

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -64,7 +64,7 @@
 
 
 (defn make-route
-  "Given a "
+  "Return an instance of Route given a pattern and action."
   [pattern action]
   {:pre [(ifn? action)]}
   (Route. pattern action))
@@ -168,7 +168,7 @@
                (merge-with vector {})))))))
 
 ;; ---------------------------------------------------------------------
-;; Dispatcher
+;; URI dispatcher
 
 (defn request-map [s]
   (let [[uri query-string] (string/split s #"\?")]

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -88,7 +88,7 @@
       [(re-pattern (str \^ pattern \$)) (remove nil? params)])))
 
 (defn ^:private compile-route
-  "Given a route return an instance of IRouteMatches."
+  "Given a string route return an instance of IRouteMatches."
   [^string s]
   (let [clauses [[#"^\*([^\s.:*/]*)" ;; Splats, named splates
                   (fn [v]
@@ -116,7 +116,13 @@
         (when-let [[_ & ms] (re-matches* re route)]
           (->> (interleave params (map js/decodeURIComponent ms))
                (partition 2)
-               (merge-with vector {})))))))
+               (merge-with vector {}))))
+      IRenderRoute
+      (-render-route [_]
+        (-render-route s))
+
+      (-render-route [_ params]
+        (-render-route s params)))))
 
 
 ;; ---------------------------------------------------------------------
@@ -135,11 +141,11 @@
       (-route-matches pattern x)))
 
   IRenderRoute
-  (-render-route [_]
+  (-render-route [this]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern)))
 
-  (-render-route [_ params]
+  (-render-route [this params]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern params)))
 

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -278,7 +278,8 @@
                  m
                  (assoc m key [value validation]))
                :else m)))
-          {} (partition 2 validations)))
+          {}
+          (partition 2 validations)))
 
 (defn ^:private params-valid? [params validations]
   (empty? (invalid-params params validations)))

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -203,9 +203,10 @@
      (uri-dispatcher routes identity))
   ([routes handler]
      (fn [uri]
-       (let [h (-> (handler identity)
+       (let [h (-> identity
+                   (wrap-query-params)
                    (wrap-route routes)
-                   (wrap-query-params))
+                   (handler))
              {:keys [route] :as req} (h (request-map uri))]
          (when route
            (let [req-map (-> (dissoc req :route)

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -256,10 +256,11 @@
 
 (defn ^:private invalid-params [params validations]
   (reduce (fn [m [key validation]]
-            (let [value (get params key)]
+            (if-let [value (get params key)]
               (if (re-matches validation value)
                 m
-                (assoc m key [value validation]))))
+                (assoc m key [value validation]))
+              m))
           {} (partition 2 validations)))
 
 (defn ^:private params-valid? [params validations]

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -33,7 +33,7 @@
   (-route-value route))
 
 (defn render-route
-  "Return a representation of route optionally with params. route must 
+  "Return a representation of route optionally with params. route must
   satisfy IRenderRoute."
   ([route] (-render-route route))
   ([route params] (-render-route route params)))
@@ -150,7 +150,6 @@
   (-render-route [this]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern)))
-
   (-render-route [this params]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern params)))
@@ -203,8 +202,8 @@
       (handler req))))
 
 (defn uri-dispatcher
-  "Return a dispatcher which when invoked with a uri attempts 
-  to locate, match, and apply a routing action. Optionally a ring-style 
+  "Return a dispatcher which when invoked with a uri attempts
+  to locate, match, and apply a routing action. Optionally a ring-style
   handler may be passed."
   ([routes]
      (uri-dispatcher routes identity))
@@ -235,28 +234,27 @@
     (-route-matches (compile-route this) route))
 
   IRenderRoute
-  (-render-route [this]
-    (-render-route this {}))
-
-  (-render-route [this params]
-    (let [{:keys [query-params] :as m} params
-          a (atom m)
-          path (.replace this (js/RegExp. ":[^\\s.:*/]+|\\*[^\\s.:*/]*" "g")
-                         (fn [$1]
-                           (let [lookup (keyword (if (= $1 "*")
-                                                   $1
-                                                   (subs $1 1)))
-                                 v (get @a lookup)
-                                 replacement (if (sequential? v)
-                                               (do
-                                                 (swap! a assoc lookup (next v))
-                                                 (codec/encode-uri (first v)))
-                                               (if v (codec/encode-uri v) $1))]
-                             replacement)))]
-      (if-let [query-string (and query-params
-                                 (codec/encode-query-params query-params))]
-        (str *route-prefix* path "?" query-string)
-        (str *route-prefix* path)))))
+  (-render-route
+    ([this] (-render-route this {}))
+    ([this params]
+     (let [{:keys [query-params] :as m} params
+           a (atom m)
+           path (.replace this (js/RegExp. ":[^\\s.:*/]+|\\*[^\\s.:*/]*" "g")
+                          (fn [$1]
+                            (let [lookup (keyword (if (= $1 "*")
+                                                    $1
+                                                    (subs $1 1)))
+                                  v (get @a lookup)
+                                  replacement (if (sequential? v)
+                                                (do
+                                                  (swap! a assoc lookup (next v))
+                                                  (codec/encode-uri (first v)))
+                                                (if v (codec/encode-uri v) $1))]
+                              replacement)))]
+       (if-let [query-string (and query-params
+                                  (codec/encode-query-params query-params))]
+         (str *route-prefix* path "?" query-string)
+         (str *route-prefix* path))))))
 
 
 ;;; RegExp
@@ -305,11 +303,10 @@
         params)))
 
   IRenderRoute
-  (-render-route [this]
-    (-render-route this {}))
-
-  (-render-route [[route-string & validations] params]
-    (let [invalid (invalid-params params validations)]
-      (if (empty? invalid)
-        (render-route route-string params)
-        (throw (ex-info "Could not build route: invalid params" invalid))))))
+  (-render-route
+    ([this] (-render-route this {}))
+    ([[route-string & validations] params]
+     (let [invalid (invalid-params params validations)]
+       (if (empty? invalid)
+         (render-route route-string params)
+         (throw (ex-info "Could not build route: invalid params" invalid)))))))

--- a/test/secretary/test/codec.cljs
+++ b/test/secretary/test/codec.cljs
@@ -1,0 +1,30 @@
+(ns secretary.test.codec
+  (:require
+   (cemerick.cljs.test :as t
+                       :include-macros true
+                       :refer [deftest testing is are])
+   (secretary.codec :as codec)))
+
+(deftest query-params-test
+  (testing "encodes query params"
+    (let [params {:id "kevin" :food "bacon"}
+          encoded (codec/encode-query-params params)]
+      (is (= (codec/decode-query-params encoded)
+             params)))
+
+    (are [x y] (= (codec/encode-query-params x) y)
+      {:x [1 2]} "x[]=1&x[]=2"
+      {:a [{:b 1} {:b 2}]} "a[0][b]=1&a[1][b]=2"
+      {:a [{:b [1 2]} {:b [3 4]}]} "a[0][b][]=1&a[0][b][]=2&a[1][b][]=3&a[1][b][]=4"))
+
+  (testing "decodes query params"
+    (let [query-string "id=kevin&food=bacong"
+          decoded (codec/decode-query-params query-string)
+          encoded (codec/encode-query-params decoded)]
+      (is (re-find #"id=kevin" query-string))
+      (is (re-find #"food=bacon" query-string)))
+
+    (are [x y] (= (codec/decode-query-params x) y)
+      "x[]=1&x[]=2" {:x ["1" "2"]}
+      "a[0][b]=1&a[1][b]=2" {:a [{:b "1"} {:b "2"}]}
+      "a[0][b][]=1&a[0][b][]=2&a[1][b][]=3&a[1][b][]=4" {:a [{:b ["1" "2"]} {:b ["3" "4"]}]})))

--- a/test/secretary/test/codec.cljs
+++ b/test/secretary/test/codec.cljs
@@ -1,9 +1,7 @@
 (ns secretary.test.codec
   (:require
-   [cemerick.cljs.test :as t]
-   [secretary.codec :as codec])
-  (:require-macros
-   [cemerick.cljs.test :refer [deftest testing is are]]))
+   [cljs.test :as t :refer-macros [deftest testing is are]]
+   [secretary.codec :as codec]))
 
 (deftest query-params-test
   (testing "encodes query params"

--- a/test/secretary/test/codec.cljs
+++ b/test/secretary/test/codec.cljs
@@ -1,9 +1,9 @@
 (ns secretary.test.codec
   (:require
-   (cemerick.cljs.test :as t
-                       :include-macros true
-                       :refer [deftest testing is are])
-   (secretary.codec :as codec)))
+   [cemerick.cljs.test :as t]
+   [secretary.codec :as codec])
+  (:require-macros
+   [cemerick.cljs.test :refer [deftest testing is are]]))
 
 (deftest query-params-test
   (testing "encodes query params"

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -1,246 +1,171 @@
 (ns secretary.test.core
-  (:require [cemerick.cljs.test]
-            [secretary.core :as secretary :include-macros true :refer [defroute]])
-  (:require-macros [cemerick.cljs.test :refer [deftest is are testing]]))
+  (:require
+   (cemerick.cljs.test :as t
+                       :include-macros true
+                       :refer [deftest testing is are])
+   (secretary.core :as s
+                   :include-macros true
+                   :refer [defroute])))
 
-
-(deftest query-params-test
-  (testing "encodes query params"
-    (let [params {:id "kevin" :food "bacon"}
-          encoded (secretary/encode-query-params params)]
-      (is (= (secretary/decode-query-params encoded)
-             params)))
-
-    (are [x y] (= (secretary/encode-query-params x) y)
-      {:x [1 2]} "x[]=1&x[]=2"
-      {:a [{:b 1} {:b 2}]} "a[0][b]=1&a[1][b]=2"
-      {:a [{:b [1 2]} {:b [3 4]}]} "a[0][b][]=1&a[0][b][]=2&a[1][b][]=3&a[1][b][]=4"))
-
-  (testing "decodes query params"
-    (let [query-string "id=kevin&food=bacong"
-          decoded (secretary/decode-query-params query-string)
-          encoded (secretary/encode-query-params decoded)]
-      (is (re-find #"id=kevin" query-string))
-      (is (re-find #"food=bacon" query-string)))
-
-    (are [x y] (= (secretary/decode-query-params x) y)
-      "x[]=1&x[]=2" {:x ["1" "2"]}
-      "a[0][b]=1&a[1][b]=2" {:a [{:b "1"} {:b "2"}]}
-      "a[0][b][]=1&a[0][b][]=2&a[1][b][]=3&a[1][b][]=4" {:a [{:b ["1" "2"]} {:b ["3" "4"]}]})))
+;; ---------------------------------------------------------------------
+;; Route matching/rendering testing
 
 (deftest route-matches-test
   (testing "non-encoded-routes"
-    (is (not (secretary/route-matches "/foo bar baz" "/foo%20bar%20baz")))
-    (is (not (secretary/route-matches "/:x" "/,")))
-    (is (not (secretary/route-matches "/:x" "/;")))
+    (is (not (s/route-matches "/foo bar baz" "/foo%20bar%20baz")))
+    (is (not (s/route-matches "/:x" "/,")))
+    (is (not (s/route-matches "/:x" "/;")))
 
-    (is (= (secretary/route-matches "/:x" "/%2C")
+    (is (= (s/route-matches "/:x" "/%2C")
            {:x ","}))
 
-    (is (= (secretary/route-matches "/:x" "/%3B")
+    (is (= (s/route-matches "/:x" "/%3B")
            {:x ";"})))
 
   (testing "utf-8 routes"
-    (is (= (secretary/route-matches "/:x" "/%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86")
+    (is (= (s/route-matches "/:x" "/%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86")
            {:x "おはよう"})))
 
   (testing "regex-routes"
-    (secretary/reset-routes!)
-
-    (is (= (secretary/route-matches #"/([a-z]+)/(\d+)" "/lol/420")
+    (is (= (s/route-matches #"/([a-z]+)/(\d+)" "/lol/420")
            ["lol" "420"]))
-    (is (not (secretary/route-matches #"/([a-z]+)/(\d+)" "/0x0A/0x0B"))))
+    (is (not (s/route-matches #"/([a-z]+)/(\d+)" "/0x0A/0x0B"))))
 
   (testing "vector routes"
-    (is (= (secretary/route-matches ["/:foo", :foo #"[0-9]+"] "/12345") {:foo "12345"}))
-    (is (not (secretary/route-matches ["/:foo", :foo #"[0-9]+"] "/haiii"))))
+    (is (= (s/route-matches ["/:foo", :foo #"[0-9]+"] "/12345")
+           {:foo "12345"}))
+    (is (not (s/route-matches ["/:foo", :foo #"[0-9]+"]
+                              "/haiii"))))
 
   (testing "splats"
-    (is (= (secretary/route-matches "*" "")
+    (is (= (s/route-matches "*" "")
            {:* ""}))
-    (is (= (secretary/route-matches "*" "/foo/bar")
+    (is (= (s/route-matches "*" "/foo/bar")
            {:* "/foo/bar"}))
-    (is (= (secretary/route-matches "*.*" "cat.bat")
+    (is (= (s/route-matches "*.*" "cat.bat")
            {:* ["cat" "bat"]}))
-    (is (= (secretary/route-matches "*path/:file.:ext" "/loller/skates/xxx.zip")
+    (is (= (s/route-matches "*path/:file.:ext" "/loller/skates/xxx.zip")
            {:path "/loller/skates"
             :file "xxx"
             :ext "zip"}))
-    (is (= (secretary/route-matches "/*a/*b/*c" "/lol/123/abc/look/at/me")
+    (is (= (s/route-matches "/*a/*b/*c" "/lol/123/abc/look/at/me")
            {:a "lol"
             :b "123"
             :c "abc/look/at/me"}))))
 
-
 (deftest render-route-test
   (testing "it interpolates correctly"
-    (is (= (secretary/render-route "/")
+    (is (= (s/render-route "/")
            "/"))
-    (is (= (secretary/render-route "/users/:id" {:id 1})
+    (is (= (s/render-route "/users/:id" {:id 1})
            "/users/1"))
-    (is (= (secretary/render-route "/users/:id/food/:food" {:id "kevin" :food "bacon"})
+    (is (= (s/render-route "/users/:id/food/:food" {:id "kevin" :food "bacon"})
            "/users/kevin/food/bacon"))
-    (is (= (secretary/render-route "/users/:id" {:id 123})
+    (is (= (s/render-route "/users/:id" {:id 123})
            "/users/123"))
-    (is (= (secretary/render-route "/users/:id" {:id 123 :query-params {:page 2 :per-page 10}})
+    (is (= (s/render-route "/users/:id" {:id 123 :query-params {:page 2 :per-page 10}})
            "/users/123?page=2&per-page=10"))
-    (is (= (secretary/render-route "/:id/:id" {:id 1})
+    (is (= (s/render-route "/:id/:id" {:id 1})
            "/1/1"))
-    (is (= (secretary/render-route "/:id/:id" {:id [1 2]})
+    (is (= (s/render-route "/:id/:id" {:id [1 2]})
            "/1/2"))
-    (is (= (secretary/render-route "/*id/:id" {:id [1 2]})
+    (is (= (s/render-route "/*id/:id" {:id [1 2]})
            "/1/2"))
-    (is (= (secretary/render-route "/*x/*y" {:x "lmao/rofl/gtfo"
+    (is (= (s/render-route "/*x/*y" {:x "lmao/rofl/gtfo"
                                              :y "k/thx/bai"})
            "/lmao/rofl/gtfo/k/thx/bai"))
-    (is (= (secretary/render-route "/*.:format" {:* "blood"
+    (is (= (s/render-route "/*.:format" {:* "blood"
                                                  :format "tarzan"})
            "/blood.tarzan"))
-    (is (= (secretary/render-route "/*.*" {:* ["stab" "wound"]})
+    (is (= (s/render-route "/*.*" {:* ["stab" "wound"]})
            "/stab.wound"))
-    (is (= (secretary/render-route ["/:foo", :foo #"[0-9]+"] {:foo "12345"}) "/12345"))
-    (is (thrown? ExceptionInfo (secretary/render-route ["/:foo", :foo #"[0-9]+"] {:foo "haiii"}))))
+    (is (= (s/render-route ["/:foo", :foo #"[0-9]+"] {:foo "12345"}) "/12345"))
+    (is (thrown? ExceptionInfo (s/render-route ["/:foo", :foo #"[0-9]+"] {:foo "haiii"}))))
 
   (testing "it encodes replacements"
-    (is (= (secretary/render-route "/users/:path" {:path "yay/for/me"}))
+    (is (= (s/render-route "/users/:path" {:path "yay/for/me"}))
         "/users/yay/for/me")
-    (is (= (secretary/render-route "/users/:email" {:email "fake@example.com"}))
+    (is (= (s/render-route "/users/:email" {:email "fake@example.com"}))
         "/users/fake%40example.com"))
 
-  (testing "it adds prefixes"
-    (binding [secretary/*config* (atom {:prefix "#"})]
-      (is (= (secretary/render-route "/users/:id" {:id 1})
-             "#/users/1"))))
-
   (testing "it leaves param in string if not in map"
-    (is (= (secretary/render-route "/users/:id" {})
+    (is (= (s/render-route "/users/:id" {})
            "/users/:id"))))
 
+;; ---------------------------------------------------------------------
+;; Dispatch testing
+
+;;; Basic dispatcher
+
+(defroute r1 "/" {} "BAM!")
+(defroute r2 "/users" {} "ZAP!")
+(defroute r3 "/users/:id" {:as params} params)
+(defroute r4 "/users/:id/food/:food" {:as params} params)
+
+(def rs [r1 r2 r3 r4])
+
+(defn d1 [uri]
+  (let [[r ms] (some (fn [r]
+                       (when-let [ms (s/route-matches r uri)]
+                         [r ms]))
+                     rs)]
+    (when r (.action r ms)))) 
 
 (deftest defroute-test
   (testing "dispatch! with basic routes"
-    (secretary/reset-routes!)
-
-    (defroute "/" [] "BAM!")
-    (defroute "/users" [] "ZAP!")
-    (defroute "/users/:id" {:as params} params)
-    (defroute "/users/:id/food/:food" {:as params} params)
-
-    (is (= (secretary/dispatch! "/")
+    (is (= (d1 "/")
            "BAM!"))
-    (is (= (secretary/dispatch! "")
-           "BAM!"))
-    (is (= (secretary/dispatch! "/users")
+    (is (= (d1 "/users")
            "ZAP!"))
-    (is (= (secretary/dispatch! "/users/1")
+    (is (= (d1 "/users/1")
            {:id "1"}))
-    (is (= (secretary/dispatch! "/users/kevin/food/bacon")
-           {:id "kevin", :food "bacon"})))
+    (is (= (d1 "/users/kevin/food/bacon")
+           {:id "kevin", :food "bacon"}))))
 
-  (testing "dispatch! with query-params"
-    (secretary/reset-routes!)
-    (defroute "/search-1" {:as params} params)
+;;; URI dispatcher
 
-    (is (not (contains? (secretary/dispatch! "/search-1")
-                        :query-params)))
+(defroute ur1 "/" {:as req}
+  req)
 
-    (is (contains? (secretary/dispatch! "/search-1?foo=bar")
-                   :query-params))
+(defroute ur2 #"/([a-z]+)" {[letters] :params qps :query-params :as req}
+  [letters qps])
 
-    (defroute "/search-2" [query-params] query-params)
+(defroute ur3 #"/([a-z]+)/(\d+)" {[letters digits] :params}
+  [letters digits])
+
+(defroute ur4 ["/:num/socks" :num #"[0-9]+"] {{:keys [num]} :params}
+  (str num "socks"))
+
+(def d2
+  (s/uri-dispatcher [ur1 ur2 ur3 ur4]))
+
+
+(deftest uri-dispatcher-test
+  (testing "uri-dispatcher (string routes)"
+    (is (contains? (d2 "/") :query-params))
+
+    (let [m (d2 "/?foo=bar")]
+      (is (and (contains? m :query-params)
+               (contains? (:query-params m) :foo))))
 
     (let [s "abc123 !@#$%^&*"
           [p1 p2] (take 2 (iterate #(apply str (shuffle %)) s))
-          r (str "/search-2?"
+          r (str "/?"
                  "foo=" (js/encodeURIComponent p1)
                  "&bar=" (js/encodeURIComponent p2))]
-      (is (= (secretary/dispatch! r)
+      (is (= (:query-params (d2 r))
              {:foo p1 :bar p2})))
 
-    (defroute #"/([a-z]+)/search" [letters {:keys [query-params]}]
-      [letters query-params])
+    (testing "uri-dispatcher (regex-routes)"
+      (is (= (d2 "/xyz/123")
+             ["xyz" "123"]))
 
-    (is (= (secretary/dispatch! "/abc/search")
-           ["abc" nil]))
+      (is (= (d2 "/abc")
+             ["abc" {}]))
 
-    (is (= (secretary/dispatch! "/abc/search?flavor=pineapple&walnuts=true")
-           ["abc" {:flavor "pineapple" :walnuts "true"}])))
+      (is (= (d2 "/abc?flavor=pineapple&walnuts=true")
+             ["abc" {:flavor "pineapple" :walnuts "true"}])))
 
-  (testing "dispatch! with regex routes"
-    (secretary/reset-routes!)
-    (defroute #"/([a-z]+)/(\d+)" [letters digits] [letters digits])
-
-    (is (= (secretary/dispatch! "/xyz/123")
-           ["xyz" "123"])))
-
-  (testing "dispatch! with vector routes"
-    (secretary/reset-routes!)
-    (defroute ["/:num/socks" :num #"[0-9]+"] {:keys [num]} (str num"socks"))
-
-    (is (= (secretary/dispatch! "/bacon/socks") nil))
-    (is (= (secretary/dispatch! "/123/socks") "123socks")))
-
-  (testing "dispatch! with named-routes and configured prefix"
-    (secretary/reset-routes!)
-
-    (binding [secretary/*config* (atom {:prefix "#"})]
-      (defroute root-route "/" [] "BAM!")
-      (defroute users-route "/users" [] "ZAP!")
-      (defroute user-route "/users/:id" {:as params} params)
-
-      (is (= (secretary/dispatch! (root-route))
-             "BAM!"))
-      (is (= (secretary/dispatch! (users-route))
-             "ZAP!"))
-      (is (= (secretary/dispatch! (user-route {:id "2"}))
-           {:id "2"}))))
-
-  (testing "named routes"
-    (secretary/reset-routes!)
-
-    (defroute food-path "/food/:food" [food])
-    (defroute search-path "/search" [query-params])
-
-    (is (fn? food-path))
-    (is (fn? (defroute "/pickles" {})))
-    (is (= (food-path {:food "biscuits"})
-           "/food/biscuits"))
-
-    (let [url (search-path {:query-params {:burritos 10, :tacos 200}})]
-      (is (re-find #"burritos=10" url))
-      (is (re-find #"tacos=200" url))))
-  
-  (testing "dispatch! with splat and no home route"
-    (secretary/reset-routes!)
-
-    (defroute "/users/:id" {:as params} params)
-    (defroute "*" [] "SPLAT")
-
-    (is (= (secretary/dispatch! "/users/1")
-           {:id "1"}))
-    (is (= (secretary/dispatch! "")
-           "SPLAT"))
-    (is (= (secretary/dispatch! "/users")
-           "SPLAT"))))
-
-(deftest locate-route
-  (testing "locate-route includes original route as last value in return vector"
-    (secretary/reset-routes!)
-
-    (defroute "/my-route/:some-param" [params])
-    (defroute #"my-regexp-route-[a-zA-Z]*" [params])
-    (defroute ["/my-vector-route/:some-param", :some-param #"[0-9]+"] [params])
-
-    (is (= "/my-route/:some-param" (secretary/locate-route-value "/my-route/100")))
-    ;; is this right? shouldn't this just return nil?
-    (is (thrown? js/Error (secretary/locate-route-value "/not-a-route")))
-
-    (let [[route & validations] (secretary/locate-route-value "/my-vector-route/100")
-          {:keys [some-param]} (apply hash-map validations)]
-      (is (= "/my-vector-route/:some-param" route))
-      (is (= (.-source #"[0-9]+")
-             (.-source some-param))))
-    (is (thrown? js/Error (secretary/locate-route-value "/my-vector-route/foo")))
-
-    (is (= (.-source #"my-regexp-route-[a-zA-Z]*")
-           (.-source (secretary/locate-route-value "my-regexp-route-test"))))))
+    (testing "uri-dispatcher (vector routes)"
+      (is (= (d2 "/bacon/socks") nil))
+      (is (= (d2 "/123/socks") "123socks")))))

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -151,6 +151,8 @@
   (testing "uri-dispatcher (string routes)"
     (is (contains? (d2 "/") :query-params))
 
+    (is (nil? (d2 nil)))
+
     (let [m (d2 "/?foo=bar")]
       (is (and (contains? m :query-params)
                (contains? (:query-params m) :foo))))

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -177,3 +177,13 @@
       (is (= (d2 "/ur4/bacon/socks") nil))
       (is (= (d2 "/ur4/123/socks") "123socks"))
       (is (= (d2 "/ur5/123") "123")))))
+
+;; ---------------------------------------------------------------------
+;; Render testing
+
+(s/defroute render1 "/render1/:id" [])
+
+(deftest render-test
+  (testing "calling a route renders it"
+    (is (= (render1 {:id 10})
+           "/render1/10"))))

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -182,8 +182,16 @@
 ;; Render testing
 
 (s/defroute render1 "/render1/:id" [])
+(s/defroute render2 ["/render2/:id" :id #"[0-9]+"] [])
+(s/defroute render3 ["/render3/:id" :id number?] [])
 
 (deftest render-test
   (testing "calling a route renders it"
     (is (= (render1 {:id 10})
-           "/render1/10"))))
+           "/render1/10"))
+    (is (= (render2 {:id "10"})
+           "/render2/10"))
+    (is (thrown? ExceptionInfo (render2 {:id "a"})))
+    (is (= (render3 {:id 10})
+           "/render3/10"))
+    (is (thrown? ExceptionInfo (render3 {:id "dip"})))))

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -92,6 +92,12 @@
     (is (= (s/render-route "/users/:id" {})
            "/users/:id"))))
 
+(deftest make-route-test
+  (testing "make-route compiles string routes"
+    (let [s "/a/:x"]
+      (is (not= (:pattern (s/make-route s identity))
+                s)))))
+
 ;; ---------------------------------------------------------------------
 ;; Dispatch testing
 

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -3,7 +3,7 @@
    [cemerick.cljs.test :as t]
    [secretary.core :as s])
   (:require-macros
-   [cemerick.cljs.test :refer [deftest testing is are])
+   [cemerick.cljs.test :refer [deftest testing is are]]))
 
 ;; ---------------------------------------------------------------------
 ;; Route matching/rendering testing
@@ -102,10 +102,10 @@
 
 ;;; Basic dispatcher
 
-(defroute r1 "/" {} "BAM!")
-(defroute r2 "/users" {} "ZAP!")
-(defroute r3 "/users/:id" {:as params} params)
-(defroute r4 "/users/:id/food/:food" {:as params} params)
+(s/defroute r1 "/" {} "BAM!")
+(s/defroute r2 "/users" {} "ZAP!")
+(s/defroute r3 "/users/:id" {:as params} params)
+(s/defroute r4 "/users/:id/food/:food" {:as params} params)
 
 (def rs [r1 r2 r3 r4])
 
@@ -129,16 +129,16 @@
 
 ;;; URI dispatcher
 
-(defroute ur1 "/" {:as req}
+(s/defroute ur1 "/" {:as req}
   req)
 
-(defroute ur2 #"/([a-z]+)" {[letters] :params qps :query-params :as req}
+(s/defroute ur2 #"/([a-z]+)" {[letters] :params qps :query-params :as req}
   [letters qps])
 
-(defroute ur3 #"/([a-z]+)/(\d+)" {[letters digits] :params}
+(s/defroute ur3 #"/([a-z]+)/(\d+)" {[letters digits] :params}
   [letters digits])
 
-(defroute ur4 ["/:num/socks" :num #"[0-9]+"] {{:keys [num]} :params}
+(s/defroute ur4 ["/:num/socks" :num #"[0-9]+"] {{:keys [num]} :params}
   (str num "socks"))
 
 (def d2

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -70,10 +70,10 @@
     (is (= (s/render-route "/*id/:id" {:id [1 2]})
            "/1/2"))
     (is (= (s/render-route "/*x/*y" {:x "lmao/rofl/gtfo"
-                                             :y "k/thx/bai"})
+                                     :y "k/thx/bai"})
            "/lmao/rofl/gtfo/k/thx/bai"))
     (is (= (s/render-route "/*.:format" {:* "blood"
-                                                 :format "tarzan"})
+                                         :format "tarzan"})
            "/blood.tarzan"))
     (is (= (s/render-route "/*.*" {:* ["stab" "wound"]})
            "/stab.wound"))

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -132,18 +132,20 @@
 (s/defroute ur1 "/" {:as req}
   req)
 
-(s/defroute ur2 #"/([a-z]+)" {[letters] :params qps :query-params :as req}
+(s/defroute ur2 #"/ur2/([a-z]+)" {[letters] :params qps :query-params :as req}
   [letters qps])
 
-(s/defroute ur3 #"/([a-z]+)/(\d+)" {[letters digits] :params}
+(s/defroute ur3 #"/ur3/([a-z]+)/(\d+)" {[letters digits] :params}
   [letters digits])
 
-(s/defroute ur4 ["/:num/socks" :num #"[0-9]+"] {{:keys [num]} :params}
+(s/defroute ur4 ["/ur4/:num/socks" :num #"[0-9]+"] {{:keys [num]} :params}
   (str num "socks"))
 
-(def d2
-  (s/uri-dispatcher [ur1 ur2 ur3 ur4]))
+(s/defroute ur5 #"/ur5/(\d+)" [d]
+  d)
 
+(def d2
+  (s/uri-dispatcher [ur1 ur2 ur3 ur4 ur5]))
 
 (deftest uri-dispatcher-test
   (testing "uri-dispatcher (string routes)"
@@ -162,15 +164,16 @@
              {:foo p1 :bar p2})))
 
     (testing "uri-dispatcher (regex-routes)"
-      (is (= (d2 "/xyz/123")
-             ["xyz" "123"]))
-
-      (is (= (d2 "/abc")
+      (is (= (d2 "/ur2/abc")
              ["abc" {}]))
 
-      (is (= (d2 "/abc?flavor=pineapple&walnuts=true")
-             ["abc" {:flavor "pineapple" :walnuts "true"}])))
+      (is (= (d2 "/ur2/abc?flavor=pineapple&walnuts=true")
+             ["abc" {:flavor "pineapple" :walnuts "true"}]))
+
+      (is (= (d2 "/ur3/xyz/123")
+             ["xyz" "123"])))
 
     (testing "uri-dispatcher (vector routes)"
-      (is (= (d2 "/bacon/socks") nil))
-      (is (= (d2 "/123/socks") "123socks")))))
+      (is (= (d2 "/ur4/bacon/socks") nil))
+      (is (= (d2 "/ur4/123/socks") "123socks"))
+      (is (= (d2 "/ur5/123") "123")))))

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -1,9 +1,7 @@
 (ns secretary.test.core
   (:require
-   [cemerick.cljs.test :as t]
-   [secretary.core :as s])
-  (:require-macros
-   [cemerick.cljs.test :refer [deftest testing is are]]))
+   [cljs.test :as t :refer-macros [deftest testing is are]]
+   [secretary.core :as s]))
 
 ;; ---------------------------------------------------------------------
 ;; Route matching/rendering testing
@@ -114,7 +112,7 @@
                        (when-let [ms (s/route-matches r uri)]
                          [r ms]))
                      rs)]
-    (when r (.action r ms)))) 
+    (when r (.action r ms))))
 
 (deftest defroute-test
   (testing "dispatch! with basic routes"

--- a/test/secretary/test/core.cljs
+++ b/test/secretary/test/core.cljs
@@ -96,7 +96,8 @@
   (testing "make-route compiles string routes"
     (let [s "/a/:x"]
       (is (not= (:pattern (s/make-route s identity))
-                s)))))
+                s)))
+    (is (thrown? js/Error (s/make-route "foo" 10)))))
 
 ;; ---------------------------------------------------------------------
 ;; Dispatch testing

--- a/test/secretary/test/runner.cljs
+++ b/test/secretary/test/runner.cljs
@@ -1,0 +1,7 @@
+(ns secretary.test.runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [secretary.test.core]
+            [secretary.test.codec]))
+
+(doo-tests 'secretary.test.core
+           'secretary.test.codec)


### PR DESCRIPTION
Version 2.0.0 is primarily focused on addressing issues #16 and #41 as well as cleaning up some of the API. As with any major release, this means breaking changes. 
### Solution to #16

Solving #16 required the removal of the global `*routes*` atom. Removing it had a dramatic impact on the code consequently
- creating a new record type `Route` (`[pattern action]`) which specifies default implementations for all of the routing protocols. It also implements `IFn` which defaults to `render-route`. 
- adding a new `make-route` function as a convenience for creating routes. This is now what `defroute` uses reducing the complexity of the macro.
- removing functions such as `locate-route` and `locate-route-value`. Since routes are no longer stored in a container managed by Secretary, these can be implemented by the library consumer.
### Solution to #41

Solving #41 required solving #16 in order to create customer dispatchers. ~~There is a new data type `Dispatcher` (`[routes handler]`) which is simply a container for housing routes and a handler function `([routes dispatch-val]`). The `Dispatcher` type implements a unary `IFn` which takes a dispatch value and delegates to the handler.~~ This means
- removing `dispatch!`. We simply do not need this function any longer.
- creating a new function `uri-dispatcher [routes handler]` which returns ~~an instance of `Dispatcher`~~ a unary function of `[uri]` that does most of the work the original `dispatch!` function did with the exception `handler` is a ring style handler. Why is it called `uri-dispatcher`? Because that is what it's designed to do: dispatch actions based on URIs. There is nothing in the routing protocols that say patterns _must_ apply to URIs. A `input-dispatcher` might be used to dispatch against the values of `<input>` element.
- removing `*config*`. This was a "fix it for now" artifact. The problem of prepending/removing prefixes and ensuring leading slashes shouldn't be a concern for Secretary. These are problems which are better addressed by the library consumer. For example, to ensure a URI has a leading `/` one can create a function which ~~creates a new instance of `Dispatcher` wrapping the `Dispatcher` return from~~ wraps `uri-dispatcher`. Prepending prefixes to `Route`s can be handled by overriding `IFn` with an implementation that does so.

``` clj
(defroute r1 "/foo/:x" {{:keys [x]} :params :as req}
  [x req])

(defroute r2 "/foo/:y/bar" {{:keys [y]} :params :as req}
  [y req])

(defroute r3 #"/bar/(\d+)" {[id] :params :as req}
  [(js/parseInt id) req])

(defroute r4 #"/bar/([a-z]+)" {[alpha] :params :as req}
  [alpha req])

(let [d (uri-dispatcher
         [r1 r2 r3 r4]
         (fn [handler]
           (fn [req]
             (let [route-name (get {r1 :foo/x
                                    r2 :foo/y
                                    r3 :bar/digit
                                    r4 :bar/alpha}
                                   (:route req)
                                   :not-found)]
               (handler (assoc req :route-name route-name))))))]
  {:r1 (d "/foo/hello") 
   :r2 (d "/foo/goodbye/bar")
   :r3 (d "/bar/100")
   :r4 (d "/bar/fizzle")})

;; =>

{:r1 ["hello" {:uri "/foo/hello"
               :query-string nil
               :query-params {}
               :params {:x "hello"}
               :route-name :foo/x}]
 :r2 ["goodbye" {:uri "/foo/goodbye/bar"
                 :query-string nil
                 :query-params {}
                 :params {:y "goodbye"}
                 :route-name :foo/y}]
 :r3 [100 {:uri "/bar/100"
           :query-string nil
           :query-params {}
           :params ["100"]
           :route-name :bar/digit}]
 :r4 ["fizzle" {:uri "/bar/fizzle"
                :query-string nil
                :query-params {}
                :params ["fizzle"]
                :route-name :bar/alpha}]}
```
### Clean up

In the spirit of Ring, query-parameter encoding/decoding and serialization has been moved from `secretary.core` to `secretary.codec`.
### Won't fix?

I do not believe, although I'm open to conversation, we need to implement #18, `defroutes`, or other concepts from Compojure. My rational, again, being that these are library consumer decisions and are trivial to implement when needed.
### Summary

This version focuses on trimming down the parts of the API we simply do not need and creating the right abstractions and functions such that solving client-side routing issues is easy and flexible. These changes will definitely break existing applications which use Secretary and upgrading will require extra on behalf of the consumer (although hopefully not much). Overall, I hope many of these changes will be welcome.
