### PR TITLE
Fixed warning when compiling the example

### DIFF
--- a/examples/example-01/example.cljs
+++ b/examples/example-01/example.cljs
@@ -35,7 +35,7 @@
 
 ;; Quick and dirty history configuration.
 (let [h (History.)]
-  (goog.events/listen h EventType/NAVIGATE #(secretary/dispatch! (.-token %)))
+  (goog.events/listen h EventType.NAVIGATE #(secretary/dispatch! (.-token %)))
   (doto h
     (.setEnabled true)))
 


### PR DESCRIPTION
Using the "quick and dirty configuration" in the example causes a Warning when compiling in recent ClojureScript versions (eg. 0.0-2311) which reads "WARNING: No such namespace: goog.history.EventType at line NN src-cljs/xxx/core.cljs"

In this thread (https://groups.google.com/forum/#!topic/clojurescript/LS9-869QpUU) David Nolen writes that "EventType/NAVIGATE is not supported. There's no truly consistent way to differentiate "static fields" from namespaces. In ClojureScript / always indicates a namespace - nothing else. Use EventType.NAVIGATE instead."
