### PR TITLE
Fix extend type syntax

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
   :profiles
   {:dev {:source-paths ["dev/" "src/"]
          :dependencies
-         [[org.clojure/clojurescript "0.0-3030"]
+         [[org.clojure/clojurescript "0.0-3211"]
           [com.cemerick/piggieback "0.1.6-SNAPSHOT"]
           [weasel "0.6.0"]
           [spellhouse/clairvoyant "0.0-33-g771b57f"]]

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -150,6 +150,7 @@
   (-render-route [this]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern)))
+
   (-render-route [this params]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern params)))

--- a/src/secretary/core.cljs
+++ b/src/secretary/core.cljs
@@ -33,7 +33,7 @@
   (-route-value route))
 
 (defn render-route
-  "Return a representation of route optionally with params. route must 
+  "Return a representation of route optionally with params. route must
   satisfy IRenderRoute."
   ([route] (-render-route route))
   ([route params] (-render-route route params)))
@@ -150,7 +150,6 @@
   (-render-route [this]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern)))
-
   (-render-route [this params]
     (when (satisfies? IRenderRoute pattern)
       (-render-route pattern params)))
@@ -203,8 +202,8 @@
       (handler req))))
 
 (defn uri-dispatcher
-  "Return a dispatcher which when invoked with a uri attempts 
-  to locate, match, and apply a routing action. Optionally a ring-style 
+  "Return a dispatcher which when invoked with a uri attempts
+  to locate, match, and apply a routing action. Optionally a ring-style
   handler may be passed."
   ([routes]
      (uri-dispatcher routes identity))
@@ -235,28 +234,27 @@
     (-route-matches (compile-route this) route))
 
   IRenderRoute
-  (-render-route [this]
-    (-render-route this {}))
-
-  (-render-route [this params]
-    (let [{:keys [query-params] :as m} params
-          a (atom m)
-          path (.replace this (js/RegExp. ":[^\\s.:*/]+|\\*[^\\s.:*/]*" "g")
-                         (fn [$1]
-                           (let [lookup (keyword (if (= $1 "*")
-                                                   $1
-                                                   (subs $1 1)))
-                                 v (get @a lookup)
-                                 replacement (if (sequential? v)
-                                               (do
-                                                 (swap! a assoc lookup (next v))
-                                                 (codec/encode-uri (first v)))
-                                               (if v (codec/encode-uri v) $1))]
-                             replacement)))]
-      (if-let [query-string (and query-params
-                                 (codec/encode-query-params query-params))]
-        (str *route-prefix* path "?" query-string)
-        (str *route-prefix* path)))))
+  (-render-route
+    ([this] (-render-route this {}))
+    ([this params]
+     (let [{:keys [query-params] :as m} params
+           a (atom m)
+           path (.replace this (js/RegExp. ":[^\\s.:*/]+|\\*[^\\s.:*/]*" "g")
+                          (fn [$1]
+                            (let [lookup (keyword (if (= $1 "*")
+                                                    $1
+                                                    (subs $1 1)))
+                                  v (get @a lookup)
+                                  replacement (if (sequential? v)
+                                                (do
+                                                  (swap! a assoc lookup (next v))
+                                                  (codec/encode-uri (first v)))
+                                                (if v (codec/encode-uri v) $1))]
+                              replacement)))]
+       (if-let [query-string (and query-params
+                                  (codec/encode-query-params query-params))]
+         (str *route-prefix* path "?" query-string)
+         (str *route-prefix* path))))))
 
 
 ;;; RegExp
@@ -305,11 +303,10 @@
         params)))
 
   IRenderRoute
-  (-render-route [this]
-    (-render-route this {}))
-
-  (-render-route [[route-string & validations] params]
-    (let [invalid (invalid-params params validations)]
-      (if (empty? invalid)
-        (render-route route-string params)
-        (throw (ex-info "Could not build route: invalid params" invalid))))))
+  (-render-route
+    ([this] (-render-route this {}))
+    ([[route-string & validations] params]
+     (let [invalid (invalid-params params validations)]
+       (if (empty? invalid)
+         (render-route route-string params)
+         (throw (ex-info "Could not build route: invalid params" invalid)))))))


### PR DESCRIPTION
…profile

The IRenderRoute implementations in extend-type forms had invalid syntax. Recent versions of cljs emit a warning for this now. See http://dev.clojure.org/jira/browse/CLJS-667 and http://dev.clojure.org/jira/browse/CLJS-104. 

Without the fix you'll see these warnings running the tests with cljs 0.0-3211
```
$ lein run-tests
    ...
WARNING: Bad extend-type method shape for protocol IRenderRoute method -render-route, method arities must be grouped together at line 229 src/secretary/core.cljs
WARNING: Bad extend-type method shape for protocol IRenderRoute method -render-route, method arities must be grouped together at line 296 src/secretary/core.cljs
    ...
```