### PR TITLE
Fix "Example with goog.History" section as per #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ vector.
 
 ```clojure
 (ns example
-  (:require [secretary.core :as secretary :include-macros true :refer [defroute]]
+  (:require [secretary.core :as secretary :refer-macros [defroute]]
             [goog.events :as events]
             [goog.history.EventType :as EventType])
   (:import goog.History))


### PR DESCRIPTION
:include-macros is no longer needed and :refer-macros is the way to do it, based on this [post](https://groups.google.com/forum/#!topic/clojurescript/FoiqNV5nunQ) (also referenced in issue #53)