### PR TITLE
Prevent the test plugin adding itself as a required dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
          [[com.cemerick/piggieback "0.1.6-SNAPSHOT"]
           [weasel "0.6.0"]]
          :plugins
-         [[com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]
+         ^:displace [[com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]
          :repl-options
          {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}
 


### PR DESCRIPTION
clojurescript.test is defined as a dependency when secretary is included in a project.

I'm not sure of the deploy process that you use (or the in-REPL testing & development either).

By adding `^:displace` to the plugin prevents it from showing in the `pom.xml` when installing.

Otherwise, a separate profile to deploy could work.
